### PR TITLE
Add Travis CI Integration

### DIFF
--- a/.eslint.js
+++ b/.eslint.js
@@ -1,0 +1,31 @@
+module.exports = {
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "indent": [
+      "error",
+      2
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "guard-for-in": 0,
+    "prefer-promise-reject-errors": 2,
+    "no-invalid-this": 0,
+  }
+};

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+---
+language: node_js
+node_js: lts/*
+sudo: required
+
+services:
+  - docker
+
+addons:
+  apt:
+    sources:
+      - debian-sid
+    packages:
+      - shellcheck
+
+matrix:
+  fast_finish: true
+
+env:
+  - TEST_RUN="./tests/test-docker.sh"
+
+before_install:
+  - npm install eslint
+  - sudo pip install yamllint
+
+install: true
+
+before_script:
+  - "./tests/test-eslint.sh"
+  - "./tests/test-shellcheck.sh"
+  - "./tests/test-yamllint.sh"
+
+script: "$TEST_RUN"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,47 @@
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 2
+  comments-indentation: enable
+  document-end: disable
+  document-start:
+    present: true
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length:
+    max: 80
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+    level: warning
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy: enable

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![Build Status](https://travis-ci.org/IBM/secret-map-dashboard.svg?branch=master)](https://travis-ci.org/IBM/secret-map-dashboard)
+
 # secret-map-dashboard

--- a/scripts/resources.sh
+++ b/scripts/resources.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script contains functions used by many of the scripts found in scripts/
+# and tests/.
+
+test_failed(){
+    echo -e >&2 "\033[0;31m$1 test failed!\033[0m"
+    exit 1
+}
+
+test_passed(){
+    echo -e "\033[0;32m$1 test passed!\033[0m"
+}
+
+is_pull_request(){
+  if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+      echo -e "\033[0;33mPull Request detected; not running $1!\033[0m"
+      exit 0
+  fi
+}

--- a/tests/test-docker.sh
+++ b/tests/test-docker.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")"/../scripts/resources.sh
+
+main(){
+    for DIRECTORY in ./containers/*; do
+        pushd "$DIRECTORY"
+        if ! docker build --quiet .; then
+            test_failed "$0"
+        fi
+        popd
+    done
+    test_passed "$0"
+}
+
+main "$@"

--- a/tests/test-eslint.sh
+++ b/tests/test-eslint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")"/../scripts/resources.sh
+
+if find . -path ./node_modules -prune -o -name '*.js' -print0 | xargs -n1 -0 ./node_modules/.bin/eslint --config .eslint.js; then
+    test_passed "$0"
+else
+    test_failed "$0"
+fi

--- a/tests/test-shellcheck.sh
+++ b/tests/test-shellcheck.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")"/../scripts/resources.sh
+
+if find . -name '*.sh' -print0 | xargs -n1 -0 shellcheck -x -s bash; then
+    test_passed "$0"
+else
+    test_failed "$0"
+fi

--- a/tests/test-yamllint.sh
+++ b/tests/test-yamllint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")"/../scripts/resources.sh
+
+# IGNORE node_modules
+if find . -path ./node_modules -prune -o \( -name '*.yml' -o -name '*.yaml' \) -print0 | xargs -n1 -0 yamllint -c .yamllint.yml; then
+    test_passed "$0"
+else
+    test_failed "$0"
+fi


### PR DESCRIPTION
We are now using a basic Travis CI configuration that:

* Lints the commonly used languages in this repository
  * Bash
  * Node JS
  * YAML
* Builds all Docker containers found in containers

Related-Issues: #11
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>