### PR TITLE
Add CI support for CSS and HTML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,15 @@ env:
   - TEST_RUN="./tests/test-docker.sh"
 
 before_install:
-  - npm install eslint
+  - npm install eslint html-lint csslint
   - sudo pip install yamllint
 
 install: true
 
 before_script:
+  - "./tests/test-csslint.sh"
   - "./tests/test-eslint.sh"
+  - "./tests/test-html-lint.sh"
   - "./tests/test-shellcheck.sh"
   - "./tests/test-yamllint.sh"
 

--- a/tests/test-csslint.sh
+++ b/tests/test-csslint.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1090
 source "$(dirname "$0")"/../scripts/resources.sh
 
-if find . -path ./node_modules -prune -o \( -name '*.yml' -o -name '*.yaml' \) -print0 | xargs -n1 -0 yamllint -c .yamllint.yml; then
+if find . -path ./node_modules -prune -o -name '*.css' -print0 | xargs -n1 -0 ./node_modules/.bin/csslint --ignore=order-alphabetical; then
     test_passed "$0"
 else
     test_failed "$0"

--- a/tests/test-html-lint.sh
+++ b/tests/test-html-lint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")"/../scripts/resources.sh
+
+if find . -path ./node_modules -prune -o \( -name '*.htm' -o -name '*.html' \) -print0 | xargs -n1 -0 -I % ./node_modules/.bin/html-lint % --verbose --strict; then
+    test_passed "$0"
+else
+    test_failed "$0"
+fi


### PR DESCRIPTION
Now all CSS and HTML files are linted during each CI run.

Related-Issues: #11
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>