### PR TITLE
Fix front-end's Dockerfile

### DIFF
--- a/containers/front-end/Dockerfile
+++ b/containers/front-end/Dockerfile
@@ -3,6 +3,7 @@ FROM node:8-alpine
 COPY app.js /
 COPY package.json /
 COPY public /public
+COPY views /views
 
 RUN npm install
 


### PR DESCRIPTION
Previous dockerfile isn't copying the views folder.
Folder is required for pug files.
This fix should now copy the file in building the image with the Dockerfile.