### PR TITLE
Add CORS for express

### DIFF
--- a/containers/map-api/app.js
+++ b/containers/map-api/app.js
@@ -5,6 +5,7 @@ const app = express();
 const mongoose = require("mongoose");
 const assert = require("assert");
 const fs = require("fs");
+const cors = require("cors");
 
 const Booths = require("./models/booth");
 const Beacons = require("./models/beacon");
@@ -40,6 +41,7 @@ mongoose.connection.on("open", function(err) {
 mongoose.connect(mongoDbUrl, mongoDbOptions);
 
 app.use(require("body-parser").json());
+app.use(cors());
 
 app.use(express.static(__dirname + "/public"));
 

--- a/containers/map-api/package.json
+++ b/containers/map-api/package.json
@@ -19,9 +19,9 @@
     "mongoose": "^4.13.x",
     "express": "^4.15.x",
     "fs": "~0.0.1",
-    "assert": "^1.4.x"
+    "assert": "^1.4.x",
+    "cors": "^2.8.x"
   },
   "author": "Anthony Amanse",
   "license": "Apache-2.0"
 }
-


### PR DESCRIPTION
Adding Cross-Origin Resource Sharing (CORS) allows access to express APIs from a different origin.
This allows the front-end's javascript to gain access to the backend map-api.