### PR TITLE
Add booth description text to map area

### DIFF
--- a/containers/front-end/src/app/conference.ts
+++ b/containers/front-end/src/app/conference.ts
@@ -2,7 +2,7 @@ import {Booth, Beacon} from './conferenceItems';
 
 export class Conference {
     eventId: string;
-    eventDescription: string;
+    eventName: string;
     location: string;
     startDate: Date;
     endDate: Date;

--- a/containers/front-end/src/app/conferenceItems.ts
+++ b/containers/front-end/src/app/conferenceItems.ts
@@ -1,12 +1,8 @@
 export class Booth {
     boothId: string;
-    unit: string;
     description: string;
     measurementUnit: string;
-    xDimension: number;
-    yDimension: number;
-    x: number;
-    y: number;
+    shape: object;
     contact: string;
 }
 

--- a/containers/front-end/src/app/dashboard.service.ts
+++ b/containers/front-end/src/app/dashboard.service.ts
@@ -16,9 +16,11 @@ export class DashboardService {
 
   /** GET conferences from the map-api server */
   getConferences(): Observable<Conference[]> {
-    return this.http.get<Conference[]>(this.mapApiURL + 'get_events')
+    return this.http.get<Conference[]>(this.mapApiURL + 'events')
       .pipe(
-        tap(conferences => console.log(`fetched conferences`)),
+        tap(conferences => {
+          console.log(`fetched conferences`);
+      }),
         catchError(this.handleError('getConferences', []))
       );
   }

--- a/containers/front-end/src/app/dashboard/dashboard.component.html
+++ b/containers/front-end/src/app/dashboard/dashboard.component.html
@@ -8,7 +8,10 @@
             </app-main-display>
     </div>
     <div class="sideDisplay">
-        <app-side-display [steps]="steps" [calories]="calories"></app-side-display>
+        <app-side-display 
+            [steps]="steps" 
+            [calories]="calories">
+        </app-side-display>
     </div>
 
 </div>

--- a/containers/front-end/src/app/main-display/main-display.component.css
+++ b/containers/front-end/src/app/main-display/main-display.component.css
@@ -1,9 +1,9 @@
-.mainDisplayEventDescriptionContainer{
+.mainDisplayEventNameContainer{
   margin: auto;
   height: 15%;
   display: flex;
   flex-direction: column;
-  border-bottom: 2px #B48E8E solid;
+  border-bottom: 3px #B48E8E solid;
 }
 .mainDisplayMapContainer{
   margin: auto;
@@ -18,10 +18,10 @@
   height: 15%;
   display: flex;
   flex-direction: column;
-  border-top: 2px #B48E8E solid;
+  border-top: 3px #B48E8E solid;
 }
 
-.mainDisplayEventDescription{
+.mainDisplayEventName{
   margin: auto;
   display: flex;
   flex-direction: row;

--- a/containers/front-end/src/app/main-display/main-display.component.html
+++ b/containers/front-end/src/app/main-display/main-display.component.html
@@ -1,6 +1,6 @@
-<div class="mainDisplayEventDescriptionContainer">
-    <div class="mainDisplayEventDescription">    
-        <span>{{conference.eventDescription }}</span>
+<div class="mainDisplayEventNameContainer">
+    <div class="mainDisplayEventName">    
+        <span>{{conference.eventName }} - {{conference.location}}</span>
     </div>
 </div>
 <div class="mainDisplayMapContainer" >

--- a/containers/front-end/src/app/main-display/main-display.component.spec.ts
+++ b/containers/front-end/src/app/main-display/main-display.component.spec.ts
@@ -30,7 +30,7 @@ describe('MainDisplayComponent', () => {
     component.conferences = [
     {
       'eventId': 'E01',
-      'eventDescription': 'Index',
+      'eventName': 'Index',
       'location': 'San Francisco',
       'startDate': new Date( '2018-02-20T00:00:00.000Z' ),
       'endDate': new Date( '2018-02-24T00:00:00.000Z' ),
@@ -46,13 +46,9 @@ describe('MainDisplayComponent', () => {
       'map': [
           {
             'contact': 'John Doe',
-            'y': 0,
-            'x': 0,
-            'yDimension': 3,
-            'xDimension': 3,
+            'shape': {'width': 3, 'height': 3, 'x': 3, 'y': 3},
             'measurementUnit': 'metre',
             'description': 'Node description',
-            'unit': 'Node',
             'boothId': 'A01'
           }
       ]

--- a/containers/front-end/src/app/map-area.directive.spec.ts
+++ b/containers/front-end/src/app/map-area.directive.spec.ts
@@ -29,13 +29,9 @@ describe('MapAreaDirective', () => {
     directive.booths = [
      {
         'contact': 'John Doe',
-        'y': 0,
-        'x': 0,
-        'yDimension': 3,
-        'xDimension': 3,
         'measurementUnit': 'metre',
         'description': 'Node description',
-        'unit': 'Node',
+        'shape': {'y': 0, 'x': 0, 'width': 3, 'height': 3},
         'boothId': 'A01'
     }
    ];

--- a/containers/front-end/src/app/map-area.directive.ts
+++ b/containers/front-end/src/app/map-area.directive.ts
@@ -15,8 +15,10 @@ export class MapAreaDirective implements AfterViewChecked {
   ngAfterViewChecked() {
     this.changeEventBlockSize(this.el.nativeElement);
     this.changeBeaconBlockSize(this.el.nativeElement);
+    this.changeBoothTextSize(this.el.nativeElement);
   }
 
+  // Changes booth blocks in proporation to the window size
   changeEventBlockSize(parent: HTMLElement) {
     if (!parent) {
       return;
@@ -33,19 +35,19 @@ export class MapAreaDirective implements AfterViewChecked {
 
     let counter  = 0;
 
-    const rectTags = Array.from(children)
-    .map(rectTag => rectTag.attributes);
+    const rectTags = Array.from(children).map(rectTag => rectTag.attributes);
 
     Array.from(rectTags)
     .map(rectTag => {
-      rectTag.setNamedItem(this.updateAttributes('width', this.booths[counter].xDimension * this.widthRatio));
-      rectTag.setNamedItem(this.updateAttributes('height', this.booths[counter].yDimension * this.heightRatio));
-      rectTag.setNamedItem(this.updateAttributes('x', this.booths[counter].x * this.widthRatio));
-      rectTag.setNamedItem(this.updateAttributes('y', this.booths[counter].y * this.heightRatio));
+      rectTag.setNamedItem(this.updateAttributes('width', this.booths[counter].shape['width'] * this.widthRatio));
+      rectTag.setNamedItem(this.updateAttributes('height', this.booths[counter].shape['height'] * this.heightRatio));
+      rectTag.setNamedItem(this.updateAttributes('x', this.booths[counter].shape['x'] * this.widthRatio));
+      rectTag.setNamedItem(this.updateAttributes('y', this.booths[counter].shape['y'] * this.heightRatio));
       counter += 1;
     });
   }
 
+  // Changes Beacon location in proporation to the window size
   changeBeaconBlockSize(parent: HTMLElement) {
     if (!parent) {
       return;
@@ -61,14 +63,48 @@ export class MapAreaDirective implements AfterViewChecked {
     this.widthRatio =  parent.getBoundingClientRect().width / 25; //  25 is the width dimenstion  reference in mongodb
     let counter = 0;
 
-    const circleTags = Array.from(children)
-    .map(circleTag => circleTag.attributes);
+    const circleTags = Array.from(children).map(circleTag => circleTag.attributes);
 
     Array.from(circleTags)
     .map(circleTag => {
-      circleTag.setNamedItem(this.updateAttributes('r', 5));
-      circleTag.setNamedItem(this.updateAttributes('cy', this.booths[counter].y * this.heightRatio));
-      circleTag.setNamedItem(this.updateAttributes('cx', this.booths[counter].x * this.widthRatio));
+      circleTag.setNamedItem(this.updateAttributes('cy', this.beacons[counter].y * this.heightRatio));
+      circleTag.setNamedItem(this.updateAttributes('cx', this.beacons[counter].x * this.widthRatio));
+      counter += 1;
+    });
+  }
+
+  // Centers booth description
+  changeBoothTextSize(parent: HTMLElement) {
+
+    if (!parent) {
+      return;
+    }
+
+    const boothTexts = parent.getElementsByClassName('boothText');
+    const rectTags = parent.getElementsByClassName('eventBlock');
+
+    if (!boothTexts || !rectTags) {
+      return;
+    }
+
+    this.heightRatio = parent.getBoundingClientRect().height / 25; // 25 is the height dimension reference in mongodb
+    this.widthRatio =  parent.getBoundingClientRect().width / 25; //  25 is the width dimenstion  reference in mongodb
+
+    let counter  = 0;
+
+    let centerRectTagHeight = 0;
+    let centerRectTagWidth = 0;
+
+    Array.from(boothTexts)
+    .map(boothText => {
+
+      centerRectTagHeight = Number(rectTags[counter].attributes.getNamedItem('y').value) +
+        Number(rectTags[counter].attributes.getNamedItem('height').value) / 2;
+      centerRectTagWidth = Number(rectTags[counter].attributes.getNamedItem('x').value) +
+        Number(rectTags[counter].attributes.getNamedItem('width').value) / 2 ;
+      boothText.attributes.setNamedItem(this.updateAttributes('x', centerRectTagWidth - boothText.getBoundingClientRect().width / 2 ));
+      boothText.attributes.setNamedItem(this.updateAttributes('y', centerRectTagHeight));
+
       counter += 1;
     });
   }
@@ -78,6 +114,7 @@ export class MapAreaDirective implements AfterViewChecked {
   onResize() {
     this.changeEventBlockSize(this.el.nativeElement);
     this.changeBeaconBlockSize(this.el.nativeElement);
+    this.changeBoothTextSize(this.el.nativeElement);
   }
 
   updateAttributes(attributeName: string, attributeValue: number ): Attr {

--- a/containers/front-end/src/app/map-area/map-area.component.css
+++ b/containers/front-end/src/app/map-area/map-area.component.css
@@ -10,6 +10,14 @@
   stroke:rgb(0,0,0);
 }
 
+.boothText{
+  fill: blue;
+  stroke-width:0;
+  stroke:rgb(0,0,0);
+  font-size: 0.75vw;
+  font-family: sans-serif;
+}
+
 .mapArea {
   margin: auto;
   height: 65vh;

--- a/containers/front-end/src/app/map-area/map-area.component.html
+++ b/containers/front-end/src/app/map-area/map-area.component.html
@@ -1,10 +1,22 @@
 <svg class="mapArea" appMapArea [booths]="booths" [beacons]="beacons">
 
     <rect *ngFor="let booth of booths"
-        [attr.x]="booth.x" [attr.y]="booth.y" [attr.width]="booth.xDimension" [attr.height]="booth.yDimension" class="eventBlock">
+        [attr.x]="booth.shape['x']"
+        [attr.y]="booth.shape['y']"
+        [attr.width]="booth.shape['width']"
+        [attr.height]="booth.shape['height']"
+        class="eventBlock">
     </rect>
 
+    <text *ngFor="let booth of booths" 
+        [attr.x]="booth.shape['x']" 
+        [attr.y]="booth.shape['y']" 
+        class="boothText"> {{booth.description}} 
+    </text>
+
     <circle *ngFor="let beacon of beacons"
-    [attr.cx]="beacon.x" [attr.cy]="beacon.y" r="2" class="beaconBlock"/>
-    
+        [attr.cx]="beacon.x" 
+        [attr.cy]="beacon.y" 
+        r="3" 
+        class="beaconBlock"/> 
 </svg>

--- a/containers/front-end/src/app/side-display/side-display.component.css
+++ b/containers/front-end/src/app/side-display/side-display.component.css
@@ -2,8 +2,8 @@
     height: 33.3%;
     display: flex;
     flex-direction: column;
-    border-bottom: 2px #B48E8E solid;
-    border-left: 2px #B48E8E solid;
+    border-bottom: 3px #B48E8E solid;
+    border-left: 3px #B48E8E solid;
 }
 
 .sideBlockBottom{
@@ -11,7 +11,7 @@
   display: flex;
   flex-direction: column;
   background-color: #FEFFFF;
-  border-left: 2px #B48E8E solid;
+  border-left: 3px #B48E8E solid;
 }
   
 .sideBlockImage{

--- a/containers/front-end/src/styles.css
+++ b/containers/front-end/src/styles.css
@@ -2,5 +2,5 @@
 body{
     padding: 0;
     margin: 0;
-    font-family: Montserrat, Helvetica, sans-serif;
+    font-family: sans-serif;
 }


### PR DESCRIPTION
* Updated front-end to comply with backend changes with the conferences model
* Made booth description to be centered in the booth blocks within the map area

Related Issues: #30
Signed-off by: Darryl Balderas <drrylbalderas@gmail.com>