### PR TITLE
Modify eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
   },
   "extends": "eslint:recommended",
   "parserOptions": {
+    "ecmaVersion": 2017,
     "sourceType": "module"
   },
   "rules": {
@@ -15,10 +16,6 @@ module.exports = {
     "linebreak-style": [
       "error",
       "unix"
-    ],
-    "quotes": [
-      "error",
-      "double"
     ],
     "semi": [
       "error",

--- a/containers/blockchain/blockchainNetwork/set-up/utils.js
+++ b/containers/blockchain/blockchainNetwork/set-up/utils.js
@@ -1,3 +1,4 @@
+/*eslint no-unused-vars: "off"*/
 'use strict';
 import {
   resolve

--- a/tests/test-eslint.sh
+++ b/tests/test-eslint.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1090
 source "$(dirname "$0")"/../scripts/resources.sh
 
-if find . -path ./node_modules -prune -o -name '*.js' -print0 | xargs -n1 -0 ./node_modules/.bin/eslint --config .eslint.js; then
+if find . -path ./node_modules -prune -o -name '*.js' -print0 | xargs -n1 -0 ./node_modules/.bin/eslint; then
     test_passed "$0"
 else
     test_failed "$0"


### PR DESCRIPTION
This commit modifies the eslint configuration file.
`.eslint.js` is renamed to `.eslintrc.js`. eslint will use this by default.
Removed rule on requiring double quotes. Single quotes are more common and favored by developers.

Related Issues: #65 
Signed-off-by: AnthonyAmanse <joe.amanse@obf.ateneo.edu>