### PR TITLE
Add unit test in travis for front-end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,15 @@ addons:
 matrix:
   fast_finish: true
 
+# env:
+#   - TEST_RUN="./tests/test-docker.sh"
+
 before_install:
   - npm install eslint html-lint csslint
   - sudo pip install yamllint
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 
 install: true
 
@@ -29,10 +35,12 @@ before_script:
   - "./tests/test-html-lint.sh"
   - "./tests/test-shellcheck.sh"
   - "./tests/test-yamllint.sh"
-
 jobs:
   include:
     - script: ./tests/test-docker.sh
     - script: >
         npm install --prefix containers/map-api &&
         npm test --prefix containers/map-api
+    - script: >
+        npm install --prefix containers/front-end &&
+        npm test --prefix containers/front-end

--- a/containers/front-end/karma.conf.js
+++ b/containers/front-end/karma.conf.js
@@ -1,33 +1,44 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
+var configuration = {
+  basePath: "",
+  frameworks: ["jasmine", "@angular/cli"],
+  plugins: [
+    require("karma-jasmine"),
+    require("karma-chrome-launcher"),
+    require("karma-jasmine-html-reporter"),
+    require("karma-coverage-istanbul-reporter"),
+    require("@angular/cli/plugins/karma")
+  ],
+  client:{
+    clearContext: false // leave Jasmine Spec Runner output visible in browser
+  },
+  coverageIstanbulReporter: {
+    reports: [ "html", "lcovonly" ],
+    fixWebpackSourcePaths: true
+  },
+  customLaunchers: {
+    Chrome_travis_ci: {
+      base: 'Chrome',
+      flags: ['--no-sandbox']
+    }
+  },
+  angularCli: {
+    environment: "dev"
+  },
+  reporters: ["progress", "kjhtml"],
+  port: 9876,
+  colors: true,
+  autoWatch: true,
+  browsers: ["Chrome"],
+  singleRun: true
+};
+
+if (process.env.TRAVIS) {
+  configuration.browsers = ['Chrome_travis_ci'];
+}
+
 
 module.exports = function (config) {
-  config.set({
-    basePath: "",
-    frameworks: ["jasmine", "@angular/cli"],
-    plugins: [
-      require("karma-jasmine"),
-      require("karma-chrome-launcher"),
-      require("karma-jasmine-html-reporter"),
-      require("karma-coverage-istanbul-reporter"),
-      require("@angular/cli/plugins/karma")
-    ],
-    client:{
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
-    },
-    coverageIstanbulReporter: {
-      reports: [ "html", "lcovonly" ],
-      fixWebpackSourcePaths: true
-    },
-    angularCli: {
-      environment: "dev"
-    },
-    reporters: ["progress", "kjhtml"],
-    port: 9876,
-    colors: true,
-    logLevel: config.LOG_INFO,
-    autoWatch: true,
-    browsers: ["Chrome"],
-    singleRun: true
-  });
+  config.set(configuration);
 };


### PR DESCRIPTION
This commit adds the unit tests for front-end in Travis.
The unit tests will now run in Travis.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>