### PR TITLE
Modify pages route on map-api

### DIFF
--- a/containers/map-api/routes/pages.js
+++ b/containers/map-api/routes/pages.js
@@ -18,7 +18,7 @@ router.post("/add", function(req, res) {
 });
 
 router.get("/", function(req, res) {
-  Pages.find(function(err, pages) {
+  Pages.find({},{},{sort: { page: 1 }},function(err, pages) {
     if (err) {
       res.send(err);
     } else {


### PR DESCRIPTION
This commit modifies /pages endpoint.
The endpoint should now return a sorted array of the pages from the MongoDB.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>