### PR TITLE
Fix fabric sdk dependency issue with grpc

### DIFF
--- a/containers/blockchain/backend/package.json
+++ b/containers/blockchain/backend/package.json
@@ -17,7 +17,7 @@
     "fabric-ca-client": "^1.0.4",
     "fabric-client": "^1.0.4",
     "fs": "0.0.1-security",
-    "grpc": "^1.8.0",
+    "grpc": "1.9.1",
     "http": "0.0.0",
     "json-style-converter": "^1.0.3",
     "long": "^3.2.0",

--- a/containers/blockchain/blockchainNetwork/package.json
+++ b/containers/blockchain/blockchainNetwork/package.json
@@ -17,7 +17,7 @@
     "fabric-client": "^1.0.4",
     "fs": "0.0.1-security",
     "fs-extra": "^5.0.0",
-    "grpc": "^1.8.0",
+    "grpc": "1.9.1",
     "http": "0.0.0",
     "json-style-converter": "^1.0.3",
     "long": "^3.2.0",


### PR DESCRIPTION
This commit fixes a dependency issue with grpc module with the fabric node sdk (maybe temporary).
The change makes the grpc module to a fixed version of 1.9.1.
Output error was: `TypeError: Cannot read property 'getConnectivityState' of undefined` from backend and blockchain-setup images.

Source: https://chat.hyperledger.org/channel/general?msg=FME6aDfnfMexWTm6g

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>