### PR TITLE
Updated chaincode

### DIFF
--- a/containers/blockchain/ccfunctions.md
+++ b/containers/blockchain/ccfunctions.md
@@ -86,7 +86,7 @@ input = {
   params: {
     userId: userId,
     fcn: makePurchase
-    args: userId, sellerId, productId, quantity
+    args: userId, sellerId, productId, quantity, contractID
   }
 }
 ```
@@ -95,6 +95,7 @@ input = {
 - userID
 - productID - the id of product with seller, picked by user through interface
 - quantity - picked by user through interface
+- contractID - must start with `c` and then `six digits` i.e c111111 or c123456
 
 
 ### Seller invoke calls


### PR DESCRIPTION
-Removed "math/rand" and "time" libraries from chaincode.  The usage of these libraries can lead to non-determinism. 
-The integration of call to `makePurchase` functions will have to create the contract id on the client side and then call the function
-The chaincode function will ensure the contract id is in the format: first character must be 'c', and then followed by six digits
